### PR TITLE
Move to arc

### DIFF
--- a/src/drivers/file/server.rs
+++ b/src/drivers/file/server.rs
@@ -266,10 +266,10 @@ mod tests {
             .iter()
             .cloned()
             .map(|sample| {
-                let messaage = sample.1;
+                let message = sample.1;
                 let parsed_message = mavlink::MavFrame::<MavMessage>::deser(
                     mavlink::MavlinkVersion::V2,
-                    &messaage.raw_bytes()[4..],
+                    &message.raw_bytes()[4..],
                 );
 
                 (sample.0, parsed_message)

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -31,7 +31,7 @@ pub struct DriverDescriptionLegacy {
 
 #[async_trait::async_trait]
 pub trait Driver: Send + Sync {
-    async fn run(&self, hub_sender: broadcast::Sender<Protocol>) -> Result<()>;
+    async fn run(&self, hub_sender: broadcast::Sender<Arc<Protocol>>) -> Result<()>;
     fn info(&self) -> DriverInfo;
 }
 

--- a/src/drivers/tcp/client.rs
+++ b/src/drivers/tcp/client.rs
@@ -25,7 +25,7 @@ impl TcpClient {
 #[async_trait::async_trait]
 impl Driver for TcpClient {
     #[instrument(level = "debug", skip(self, hub_sender))]
-    async fn run(&self, hub_sender: broadcast::Sender<Protocol>) -> Result<()> {
+    async fn run(&self, hub_sender: broadcast::Sender<Arc<Protocol>>) -> Result<()> {
         let server_addr = &self.remote_addr;
         let hub_sender = Arc::new(hub_sender);
 

--- a/src/drivers/tcp/server.rs
+++ b/src/drivers/tcp/server.rs
@@ -26,7 +26,7 @@ impl TcpServer {
     async fn handle_client(
         socket: TcpStream,
         remote_addr: String,
-        hub_sender: Arc<broadcast::Sender<Protocol>>,
+        hub_sender: Arc<broadcast::Sender<Arc<Protocol>>>,
     ) -> Result<()> {
         let hub_receiver = hub_sender.subscribe();
 
@@ -53,7 +53,7 @@ impl TcpServer {
 #[async_trait::async_trait]
 impl Driver for TcpServer {
     #[instrument(level = "debug", skip(self, hub_sender))]
-    async fn run(&self, hub_sender: broadcast::Sender<Protocol>) -> Result<()> {
+    async fn run(&self, hub_sender: broadcast::Sender<Arc<Protocol>>) -> Result<()> {
         let listener = TcpListener::bind(&self.local_addr).await?;
         let hub_sender = Arc::new(hub_sender);
 

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -10,7 +10,7 @@ use crate::drivers::{Driver, DriverInfo};
 
 pub struct Hub {
     drivers: Arc<RwLock<HashMap<u64, Arc<dyn Driver>>>>,
-    bcst_sender: broadcast::Sender<Protocol>,
+    bcst_sender: broadcast::Sender<Arc<Protocol>>,
     last_driver_id: Arc<RwLock<u64>>,
     component_id: Arc<RwLock<u8>>,
     system_id: Arc<RwLock<u8>>,
@@ -89,7 +89,7 @@ impl Hub {
     }
 
     async fn heartbeat_task(
-        bcst_sender: broadcast::Sender<Protocol>,
+        bcst_sender: broadcast::Sender<Arc<Protocol>>,
         system_id: Arc<RwLock<u8>>,
         component_id: Arc<RwLock<u8>>,
         frequency: Arc<RwLock<f32>>,
@@ -123,14 +123,14 @@ impl Hub {
             let mut message_raw = Protocol::new("", MAVLinkV2MessageRaw::new());
             message_raw.serialize_message(header, &message);
 
-            if let Err(error) = bcst_sender.send(message_raw) {
+            if let Err(error) = bcst_sender.send(Arc::new(message_raw)) {
                 error!("Failed to send HEARTBEAT message: {error}");
             }
         }
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub fn get_sender(&self) -> broadcast::Sender<Protocol> {
+    pub fn get_sender(&self) -> broadcast::Sender<Arc<Protocol>> {
         self.bcst_sender.clone()
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,7 +8,7 @@ use mavlink::{ardupilotmega::MavMessage, MAVLinkV2MessageRaw};
 
 use tracing::*;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Protocol {
     pub origin: String,
     message: MAVLinkV2MessageRaw,


### PR DESCRIPTION
The idea of this change is to prepare the drivers to have multiple callbacks, which will be used as filters. Why? Because instead of copying the 300 bytes of data for each filter and for each channel's subscriber, we use a smart pointer.

The main drawback is that this Arc can cause a memory leak if the implementation of both Drivers and their callbacks clones it to a forever-living entity, like a loop task or a task that gets locked somehow.

