### PR TITLE
Add stats

### DIFF
--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast;
 use tracing::*;
 use url::Url;
 
-use crate::protocol::Protocol;
+use crate::{protocol::Protocol, stats::driver::DriverStats};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Type {
@@ -36,7 +36,7 @@ pub struct DriverDescriptionLegacy {
 }
 
 #[async_trait::async_trait]
-pub trait Driver: Send + Sync {
+pub trait Driver: Send + Sync + DriverStats {
     async fn run(&self, hub_sender: broadcast::Sender<Arc<Protocol>>) -> Result<()>;
     fn info(&self) -> Box<dyn DriverInfo>;
 }
@@ -224,6 +224,8 @@ mod tests {
     use tokio::sync::RwLock;
     use tracing::*;
 
+    use crate::stats::driver::DriverStatsInfo;
+
     use super::*;
 
     #[test]
@@ -242,6 +244,7 @@ mod tests {
     pub struct ExampleDriver {
         on_message_input: Callbacks<Arc<Protocol>>,
         on_message_output: Callbacks<Arc<Protocol>>,
+        stats: Arc<RwLock<DriverStatsInfo>>,
     }
 
     impl ExampleDriver {
@@ -249,6 +252,7 @@ mod tests {
             ExampleDriverBuilder(Self {
                 on_message_input: Callbacks::new(),
                 on_message_output: Callbacks::new(),
+                stats: Arc::new(RwLock::new(DriverStatsInfo::default())),
             })
         }
     }
@@ -275,6 +279,12 @@ mod tests {
             let mut hub_receiver = hub_sender.subscribe();
 
             while let Ok(message) = hub_receiver.recv().await {
+                self.stats
+                    .write()
+                    .await
+                    .update_input(Arc::clone(&message))
+                    .await;
+
                 for future in self.on_message_input.call_all(Arc::clone(&message)) {
                     if let Err(error) = future.await {
                         debug!(
@@ -292,6 +302,20 @@ mod tests {
 
         fn info(&self) -> Box<dyn DriverInfo> {
             Box::new(ExampleDriverInfo)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DriverStats for ExampleDriver {
+        async fn stats(&self) -> DriverStatsInfo {
+            self.stats.read().await.clone()
+        }
+
+        async fn reset_stats(&self) {
+            *self.stats.write().await = DriverStatsInfo {
+                input: None,
+                output: None,
+            }
         }
     }
 

--- a/src/hub/mod.rs
+++ b/src/hub/mod.rs
@@ -9,8 +9,11 @@ use std::{
 use anyhow::Result;
 use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
 
-use crate::drivers::{Driver, DriverInfo};
-use crate::protocol::Protocol;
+use crate::{
+    drivers::{Driver, DriverInfo},
+    protocol::Protocol,
+    stats::driver::DriverStatsInfo,
+};
 
 use actor::HubActor;
 use protocol::HubCommand;
@@ -76,5 +79,26 @@ impl Hub {
             .await?;
         let res = response_rx.await?;
         Ok(res)
+    }
+
+    pub async fn stats(&self) -> Result<Vec<(String, DriverStatsInfo)>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HubCommand::GetStats {
+                response: response_tx,
+            })
+            .await?;
+        let res = response_rx.await?;
+        Ok(res)
+    }
+
+    pub async fn reset_all_stats(&self) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HubCommand::ResetAllStats {
+                response: response_tx,
+            })
+            .await?;
+        response_rx.await?
     }
 }

--- a/src/hub/protocol.rs
+++ b/src/hub/protocol.rs
@@ -6,6 +6,7 @@ use tokio::sync::{broadcast, oneshot};
 use crate::{
     drivers::{Driver, DriverInfo},
     protocol::Protocol,
+    stats::driver::DriverStatsInfo,
 };
 
 pub enum HubCommand {
@@ -22,5 +23,11 @@ pub enum HubCommand {
     },
     GetSender {
         response: oneshot::Sender<broadcast::Sender<Arc<Protocol>>>,
+    },
+    GetStats {
+        response: oneshot::Sender<Vec<(String, DriverStatsInfo)>>,
+    },
+    ResetAllStats {
+        response: oneshot::Sender<Result<()>>,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod drivers;
 mod hub;
 mod logger;
 mod protocol;
+mod stats;
 
 use std::sync::Arc;
 
@@ -30,6 +31,8 @@ async fn main() -> Result<()> {
     for driver in cli::endpoints() {
         hub.add_driver(driver).await?;
     }
+
+    let _stats = stats::Stats::new(hub.clone(), tokio::time::Duration::from_secs(1)).await;
 
     wait_ctrlc().await;
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -11,6 +11,7 @@ use tracing::*;
 #[derive(Debug, PartialEq)]
 pub struct Protocol {
     pub origin: String,
+    pub timestamp: u64,
     message: MAVLinkV2MessageRaw,
 }
 
@@ -18,6 +19,15 @@ impl Protocol {
     pub fn new(origin: &str, message: MAVLinkV2MessageRaw) -> Self {
         Self {
             origin: origin.to_string(),
+            timestamp: chrono::Utc::now().timestamp_micros() as u64,
+            message,
+        }
+    }
+
+    pub fn new_with_timestamp(timestamp: u64, origin: &str, message: MAVLinkV2MessageRaw) -> Self {
+        Self {
+            origin: origin.to_string(),
+            timestamp,
             message,
         }
     }

--- a/src/stats/actor.rs
+++ b/src/stats/actor.rs
@@ -1,0 +1,245 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use anyhow::Result;
+use tokio::sync::{mpsc, RwLock};
+use tracing::*;
+
+use crate::{
+    hub::Hub,
+    stats::{
+        driver::{DriverStatsInfo, DriverStatsInfoInner},
+        DriverStats, DriverStatsInner, StatsCommand,
+    },
+};
+
+pub struct StatsActor {
+    hub: Hub,
+    start_time: Arc<RwLock<u64>>,
+    update_period: Arc<RwLock<tokio::time::Duration>>,
+    last_raw: Arc<RwLock<Vec<(String, DriverStatsInfo)>>>,
+    driver_stats: Arc<RwLock<Vec<(String, DriverStats)>>>,
+}
+
+impl StatsActor {
+    pub async fn start(mut self, mut receiver: mpsc::Receiver<StatsCommand>) {
+        let task = tokio::spawn({
+            let hub = self.hub.clone();
+            let update_period = Arc::clone(&self.update_period);
+            let last_raw = Arc::clone(&self.last_raw);
+            let driver_stats = Arc::clone(&self.driver_stats);
+            let start_time = Arc::clone(&self.start_time);
+
+            async move {
+                loop {
+                    update_driver_stats(&hub, &last_raw, &driver_stats, &start_time).await;
+
+                    tokio::time::sleep(*update_period.read().await).await;
+                }
+            }
+        });
+
+        while let Some(command) = receiver.recv().await {
+            match command {
+                StatsCommand::SetPeriod { period, response } => {
+                    let result = self.set_period(period).await;
+                    let _ = response.send(result);
+                }
+                StatsCommand::Reset { response } => {
+                    let result = self.reset().await;
+                    let _ = response.send(result);
+                }
+                StatsCommand::GetDriversStats { response } => {
+                    let result = self.drivers_stats().await;
+                    let _ = response.send(result);
+                }
+            }
+        }
+
+        task.abort();
+    }
+
+    #[instrument(level = "debug", skip(hub))]
+    pub async fn new(hub: Hub, update_period: tokio::time::Duration) -> Self {
+        let update_period = Arc::new(RwLock::new(update_period));
+        let last_raw = Arc::new(RwLock::new(Vec::new()));
+        let driver_stats = Arc::new(RwLock::new(Vec::new()));
+        let start_time = Arc::new(RwLock::new(chrono::Utc::now().timestamp_micros() as u64));
+
+        Self {
+            hub,
+            update_period,
+            last_raw,
+            driver_stats,
+            start_time,
+        }
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub async fn drivers_stats(&mut self) -> Result<Vec<(String, DriverStats)>> {
+        let drivers_stats = self.driver_stats.read().await.clone();
+
+        Ok(drivers_stats)
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub async fn set_period(&mut self, period: tokio::time::Duration) -> Result<()> {
+        *self.update_period.write().await = period;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub async fn reset(&mut self) -> Result<()> {
+        // note: hold the driver_stats locked until the hub clear each driver stats to minimize weird states
+        let mut driver_stats = self.driver_stats.write().await;
+        if let Err(error) = self.hub.reset_all_stats().await {
+            error!("Failed resetting driver stats: {error:?}");
+        }
+        *self.start_time.write().await = chrono::Utc::now().timestamp_micros() as u64;
+        self.last_raw.write().await.clear();
+        driver_stats.clear();
+
+        Ok(())
+    }
+}
+
+#[instrument(level = "debug", skip_all)]
+async fn update_driver_stats(
+    hub: &Hub,
+    last_raw: &Arc<RwLock<Vec<(String, DriverStatsInfo)>>>,
+    driver_stats: &Arc<RwLock<Vec<(String, DriverStats)>>>,
+    start_time: &Arc<RwLock<u64>>,
+) {
+    let last_raw_stats: Vec<(String, DriverStatsInfo)> = last_raw.read().await.clone();
+    let current_raw_stats: Vec<(String, DriverStatsInfo)> = hub.stats().await.unwrap();
+
+    let last_map: HashMap<_, _> = last_raw_stats.into_iter().collect();
+    let current_map: HashMap<_, _> = current_raw_stats
+        .iter()
+        .map(|(name, raw)| (name.clone(), raw.clone()))
+        .collect();
+
+    let merged_keys: HashSet<String> = last_map.keys().chain(current_map.keys()).cloned().collect();
+
+    let merged_stats: Vec<(String, (Option<DriverStatsInfo>, Option<DriverStatsInfo>))> =
+        merged_keys
+            .into_iter()
+            .map(|name| {
+                let last = last_map.get(&name).cloned();
+                let current = current_map.get(&name).cloned();
+                (name, (last, current))
+            })
+            .collect();
+
+    let mut new_driver_stats = Vec::new();
+
+    let start_time = start_time.read().await.clone();
+
+    for (name, (last, current)) in merged_stats {
+        if let Some(current_stats) = current {
+            let new_input_stats = calculate_driver_stats(
+                last.as_ref().and_then(|l| l.input.clone()),
+                current_stats.input.clone(),
+                start_time,
+            );
+            let new_output_stats = calculate_driver_stats(
+                last.as_ref().and_then(|l| l.output.clone()),
+                current_stats.output.clone(),
+                start_time,
+            );
+
+            new_driver_stats.push((
+                name,
+                DriverStats {
+                    input: new_input_stats,
+                    output: new_output_stats,
+                },
+            ));
+        }
+    }
+
+    trace!("{new_driver_stats:#?}");
+
+    *driver_stats.write().await = new_driver_stats;
+    *last_raw.write().await = current_raw_stats;
+}
+
+/// Function to calculate the driver stats for either input or output, with proper averages
+#[instrument(level = "debug")]
+fn calculate_driver_stats(
+    last_stats: Option<DriverStatsInfoInner>,
+    current_stats: Option<DriverStatsInfoInner>,
+    start_time: u64,
+) -> Option<DriverStatsInner> {
+    if let Some(current_stats) = current_stats {
+        let time_diff = time_diff(last_stats.as_ref(), &current_stats);
+        let total_time = total_time_since_start(start_time, &current_stats);
+
+        let diff_messages = current_stats.messages as u64
+            - last_stats.as_ref().map_or(0, |stats| stats.messages as u64);
+        let total_messages = current_stats.messages as u64;
+        let messages_per_second = divide_safe(diff_messages as f64, time_diff);
+        let average_messages_per_second = divide_safe(total_messages as f64, total_time);
+
+        let diff_bytes =
+            current_stats.bytes as u64 - last_stats.as_ref().map_or(0, |stats| stats.bytes as u64);
+        let total_bytes = current_stats.bytes as u64;
+        let bytes_per_second = divide_safe(diff_bytes as f64, time_diff);
+        let average_bytes_per_second = divide_safe(total_bytes as f64, total_time);
+
+        let delay = divide_safe(current_stats.delay as f64, current_stats.messages as f64);
+        let last_delay = divide_safe(
+            last_stats.as_ref().map_or(0f64, |stats| stats.delay as f64),
+            last_stats
+                .as_ref()
+                .map_or(0f64, |stats| stats.messages as f64),
+        );
+        let jitter = (delay - last_delay).abs();
+
+        Some(DriverStatsInner {
+            last_message_time: current_stats.last_update,
+            total_bytes,
+            bytes_per_second,
+            average_bytes_per_second,
+            total_messages,
+            messages_per_second,
+            average_messages_per_second,
+            delay,
+            jitter,
+        })
+    } else {
+        None
+    }
+}
+
+/// Function to calculate the total time since the start (in seconds)
+#[instrument(level = "debug")]
+fn total_time_since_start(start_time: u64, current_stats: &DriverStatsInfoInner) -> f64 {
+    (current_stats.last_update as f64 - start_time as f64) / 1_000_000.0
+}
+
+/// Function to calculate the time difference (in seconds)
+#[instrument(level = "debug")]
+fn time_diff(
+    last_stats: Option<&DriverStatsInfoInner>,
+    current_stats: &DriverStatsInfoInner,
+) -> f64 {
+    if let Some(last_stats) = last_stats {
+        // Microseconds to seconds
+        (current_stats.last_update as f64 - last_stats.last_update as f64) / 1_000_000.0
+    } else {
+        f64::INFINITY
+    }
+}
+
+#[instrument(level = "debug")]
+fn divide_safe(numerator: f64, denominator: f64) -> f64 {
+    if denominator > 0.0 {
+        numerator / denominator
+    } else {
+        0.0
+    }
+}

--- a/src/stats/driver.rs
+++ b/src/stats/driver.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use crate::protocol::Protocol;
+
+#[async_trait::async_trait]
+pub trait DriverStats {
+    async fn stats(&self) -> DriverStatsInfo;
+    async fn reset_stats(&self);
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DriverStatsInfo {
+    pub input: Option<DriverStatsInfoInner>,
+    pub output: Option<DriverStatsInfoInner>,
+}
+
+impl DriverStatsInfo {
+    pub async fn update_input(&mut self, message: Arc<Protocol>) {
+        if let Some(stats) = self.input.as_mut() {
+            stats.update(message).await;
+        } else {
+            self.input.replace(DriverStatsInfoInner::default());
+        }
+    }
+
+    pub async fn update_output(&mut self, message: Arc<Protocol>) {
+        if let Some(stats) = self.output.as_mut() {
+            stats.update(message).await;
+        } else {
+            self.output.replace(DriverStatsInfoInner::default());
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DriverStatsInfoInner {
+    pub last_update: u64,
+    pub messages: usize,
+    pub bytes: usize,
+    pub delay: u64,
+}
+
+impl Default for DriverStatsInfoInner {
+    fn default() -> Self {
+        Self {
+            last_update: chrono::Utc::now().timestamp_micros() as u64,
+            messages: 0,
+            bytes: 0,
+            delay: 0,
+        }
+    }
+}
+
+impl DriverStatsInfoInner {
+    pub async fn update(&mut self, message: Arc<Protocol>) {
+        self.last_update = chrono::Utc::now().timestamp_micros() as u64;
+        self.bytes += message.raw_bytes().len();
+        self.messages += 1;
+        self.delay += self.last_update - message.timestamp;
+    }
+}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,0 +1,81 @@
+mod actor;
+pub mod driver;
+mod protocol;
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use tokio::sync::{mpsc, oneshot};
+
+use actor::StatsActor;
+use protocol::StatsCommand;
+
+use crate::hub::Hub;
+
+#[derive(Debug, Clone)]
+pub struct DriverStats {
+    input: Option<DriverStatsInner>,
+    output: Option<DriverStatsInner>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DriverStatsInner {
+    last_message_time: u64,
+
+    total_bytes: u64,
+    bytes_per_second: f64,
+    average_bytes_per_second: f64,
+
+    total_messages: u64,
+    messages_per_second: f64,
+    average_messages_per_second: f64,
+
+    delay: f64,
+    jitter: f64,
+}
+
+#[derive(Clone)]
+pub struct Stats {
+    sender: mpsc::Sender<StatsCommand>,
+    task: Arc<Mutex<tokio::task::JoinHandle<()>>>,
+}
+
+impl Stats {
+    pub async fn new(hub: Hub, update_period: tokio::time::Duration) -> Self {
+        let (sender, receiver) = mpsc::channel(32);
+        let actor = StatsActor::new(hub, update_period).await;
+        let task = Arc::new(Mutex::new(tokio::spawn(actor.start(receiver))));
+        Self { sender, task }
+    }
+
+    pub async fn driver_stats(&mut self) -> Result<Vec<(String, DriverStats)>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(StatsCommand::GetDriversStats {
+                response: response_tx,
+            })
+            .await?;
+        response_rx.await?
+    }
+
+    pub async fn set_period(&mut self, period: tokio::time::Duration) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(StatsCommand::SetPeriod {
+                period,
+                response: response_tx,
+            })
+            .await?;
+        response_rx.await?
+    }
+
+    pub async fn reset(&mut self) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(StatsCommand::Reset {
+                response: response_tx,
+            })
+            .await?;
+        response_rx.await?
+    }
+}

--- a/src/stats/protocol.rs
+++ b/src/stats/protocol.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+use tokio::sync::oneshot;
+
+use crate::stats::DriverStats;
+
+pub enum StatsCommand {
+    SetPeriod {
+        period: tokio::time::Duration,
+        response: oneshot::Sender<Result<()>>,
+    },
+    Reset {
+        response: oneshot::Sender<Result<()>>,
+    },
+    GetDriversStats {
+        response: oneshot::Sender<Result<Vec<(String, DriverStats)>>>,
+    },
+}


### PR DESCRIPTION
This adds a StatsDriver with a configurable update interval, which uses each Driver's reported (cumulative) stats to compute stats for each channel over time, which in the future can be consumed via REST or Web Socket and displayed/plotted. 

Example of data:

![image](https://github.com/user-attachments/assets/af31539c-59dc-4e2e-a976-931803360bb6)

