### PR TITLE
src: Make Hub into a thread-safe facade that interacts with the hub actor

### DIFF
--- a/src/hub/mod.rs
+++ b/src/hub/mod.rs
@@ -1,0 +1,80 @@
+mod actor;
+mod protocol;
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::Result;
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+
+use crate::drivers::{Driver, DriverInfo};
+use crate::protocol::Protocol;
+
+use actor::HubActor;
+use protocol::HubCommand;
+
+#[derive(Clone)]
+pub struct Hub {
+    sender: mpsc::Sender<HubCommand>,
+    task: Arc<Mutex<tokio::task::JoinHandle<()>>>,
+}
+
+impl Hub {
+    pub async fn new(
+        buffer_size: usize,
+        component_id: Arc<RwLock<u8>>,
+        system_id: Arc<RwLock<u8>>,
+        frequency: Arc<RwLock<f32>>,
+    ) -> Self {
+        let (sender, receiver) = mpsc::channel(32);
+        let hub = HubActor::new(buffer_size, component_id, system_id, frequency).await;
+        let task = Arc::new(Mutex::new(tokio::spawn(hub.start(receiver))));
+        Self { sender, task }
+    }
+
+    pub async fn add_driver(&self, driver: Arc<dyn Driver>) -> Result<u64> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HubCommand::AddDriver {
+                driver,
+                response: response_tx,
+            })
+            .await?;
+        response_rx.await?
+    }
+
+    pub async fn remove_driver(&self, id: u64) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HubCommand::RemoveDriver {
+                id,
+                response: response_tx,
+            })
+            .await?;
+        response_rx.await?
+    }
+
+    pub async fn drivers(&self) -> Result<HashMap<u64, Box<dyn DriverInfo>>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HubCommand::GetDrivers {
+                response: response_tx,
+            })
+            .await?;
+        let res = response_rx.await?;
+        Ok(res)
+    }
+
+    pub async fn sender(&self) -> Result<broadcast::Sender<Arc<Protocol>>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HubCommand::GetSender {
+                response: response_tx,
+            })
+            .await?;
+        let res = response_rx.await?;
+        Ok(res)
+    }
+}

--- a/src/hub/protocol.rs
+++ b/src/hub/protocol.rs
@@ -1,0 +1,26 @@
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Result;
+use tokio::sync::{broadcast, oneshot};
+
+use crate::{
+    drivers::{Driver, DriverInfo},
+    protocol::Protocol,
+};
+
+pub enum HubCommand {
+    AddDriver {
+        driver: Arc<dyn Driver>,
+        response: oneshot::Sender<Result<u64>>,
+    },
+    RemoveDriver {
+        id: u64,
+        response: oneshot::Sender<Result<()>>,
+    },
+    GetDrivers {
+        response: oneshot::Sender<HashMap<u64, Box<dyn DriverInfo>>>,
+    },
+    GetSender {
+        response: oneshot::Sender<broadcast::Sender<Arc<Protocol>>>,
+    },
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
 
     wait_ctrlc().await;
 
-    for (id, driver_info) in hub.drivers().await {
+    for (id, driver_info) in hub.drivers().await? {
         debug!("Removing driver id {id:?} ({driver_info:?})");
         hub.remove_driver(id).await?;
     }


### PR DESCRIPTION
This allows us to have multiple controllers, like a TUI and a REST working concurrently while also allowing multiple Hubs to be instantiated, if needed.