### PR TITLE
Fix cli on tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "mavlink",
  "mavlink-codec",
  "mime_guess",
+ "once_cell",
  "regex",
  "ringbuffer",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ shellexpand = "3.1"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5.4.4"
 tokio-util = { version = "0.7", features = [ "codec", "net" ] }
+once_cell = "1.20"
 url = { version = "2.5.2", features = ["serde"] }
 uuid = { version = "1", features = ["v5", "v4", "serde"] }
 mime_guess = "2.0.5"

--- a/src/lib/drivers/mod.rs
+++ b/src/lib/drivers/mod.rs
@@ -367,7 +367,7 @@ mod tests {
             vec![]
         }
 
-        fn create_endpoint_from_url(&self, url: &url::Url) -> Option<Arc<dyn Driver>> {
+        fn create_endpoint_from_url(&self, _url: &url::Url) -> Option<Arc<dyn Driver>> {
             None
         }
     }


### PR DESCRIPTION
This will allow us to fix the test errors introduced by #101.

The problem happens when a test code calls any of the functions of the cli module, which then makes the `lazy_static` to create `cli::Args` from the commandline of the binary being executed, conflicting with the test harness/setup.

This change allows us to define the parsed `cli::Args` so that it won't conflict with the arguments being passed to the test harness/setup.

.. yeah, this is a drawback of singletons using `lazy_static`.