### PR TITLE
Fix use order 

### DIFF
--- a/src/lib/drivers/fake.rs
+++ b/src/lib/drivers/fake.rs
@@ -1,7 +1,7 @@
-use bytes::{BufMut, BytesMut};
 use std::sync::Arc;
 
 use anyhow::Result;
+use bytes::{BufMut, BytesMut};
 use mavlink_codec::{v2::V2Packet, Packet};
 use tokio::sync::{broadcast, RwLock};
 use tracing::*;

--- a/src/lib/drivers/mod.rs
+++ b/src/lib/drivers/mod.rs
@@ -241,12 +241,11 @@ mod tests {
     use tokio::sync::RwLock;
     use tracing::*;
 
+    use super::*;
     use crate::{
         callbacks::{Callbacks, MessageCallback},
         stats::{accumulated::driver::AccumulatedDriverStats, driver::DriverUuid},
     };
-
-    use super::*;
 
     #[test]
     fn test_unique_endpoints() {

--- a/src/lib/hub/mod.rs
+++ b/src/lib/hub/mod.rs
@@ -3,9 +3,11 @@ mod protocol;
 
 use std::sync::{Arc, Mutex};
 
+use actor::HubActor;
 use anyhow::Result;
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
+use protocol::HubCommand;
 use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
 
 use crate::{
@@ -20,9 +22,6 @@ use crate::{
         driver::DriverUuid,
     },
 };
-
-use actor::HubActor;
-use protocol::HubCommand;
 
 lazy_static! {
     static ref HUB: Hub = Hub::new(

--- a/src/lib/logger.rs
+++ b/src/lib/logger.rs
@@ -3,8 +3,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::cli;
-
 use lazy_static::lazy_static;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use tokio::sync::broadcast::{Receiver, Sender};
@@ -15,6 +13,8 @@ use tracing_subscriber::{
     layer::SubscriberExt,
     EnvFilter, Layer,
 };
+
+use crate::cli;
 
 struct BroadcastWriter {
     sender: Sender<String>,

--- a/src/lib/stats/accumulated/driver.rs
+++ b/src/lib/stats/accumulated/driver.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 use indexmap::IndexMap;
 use serde::Serialize;
 
-use crate::{drivers::DriverInfo, protocol::Protocol, stats::driver::DriverUuid};
-
 use super::AccumulatedStatsInner;
+use crate::{drivers::DriverInfo, protocol::Protocol, stats::driver::DriverUuid};
 
 pub type AccumulatedDriversStats = IndexMap<DriverUuid, AccumulatedDriverStats>;
 

--- a/src/lib/stats/accumulated/messages.rs
+++ b/src/lib/stats/accumulated/messages.rs
@@ -3,12 +3,11 @@ use std::sync::Arc;
 use indexmap::IndexMap;
 use serde::Serialize;
 
+use super::AccumulatedStatsInner;
 use crate::{
     protocol::Protocol,
     stats::messages::{ComponentId, MessageId, SystemId},
 };
-
-use super::AccumulatedStatsInner;
 
 #[derive(Default, Clone, Debug, Serialize)]
 pub struct AccumulatedHubMessagesStats {

--- a/src/lib/stats/mod.rs
+++ b/src/lib/stats/mod.rs
@@ -6,16 +6,15 @@ mod protocol;
 
 use std::sync::{Arc, Mutex};
 
-use anyhow::Result;
-use lazy_static::lazy_static;
-use serde::Serialize;
-use tokio::sync::{mpsc, oneshot};
-
 use accumulated::AccumulatedStatsInner;
 use actor::StatsActor;
+use anyhow::Result;
 use driver::DriversStats;
+use lazy_static::lazy_static;
 use messages::HubMessagesStats;
 use protocol::StatsCommand;
+use serde::Serialize;
+use tokio::sync::{mpsc, oneshot};
 
 lazy_static! {
     static ref STATS: Stats = Stats::new(tokio::time::Duration::from_secs(1));

--- a/src/lib/stats/protocol.rs
+++ b/src/lib/stats/protocol.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::stats::{DriversStats, StatsInner};
-
 use super::messages::HubMessagesStats;
+use crate::stats::{DriversStats, StatsInner};
 
 pub enum StatsCommand {
     SetPeriod {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::*;
-use tracing::*;
-
 use mavlink_server::{cli, hub, logger, web};
+use tracing::*;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
 async fn main() -> Result<()> {


### PR DESCRIPTION
Sort to use: std, external, crate, as pointed in: https://github.com/bluerobotics/mavlink-server/pull/104#discussion_r1881940663