### PR TITLE
src: drivers: mod: Ignore :// when running legacy mode

### DIFF
--- a/src/lib/drivers/mod.rs
+++ b/src/lib/drivers/mod.rs
@@ -138,6 +138,10 @@ impl std::fmt::Debug for dyn DriverInfo {
 }
 
 fn process_old_format(entry: &str) -> Option<DriverDescriptionLegacy> {
+    if entry.contains("://") {
+        return None;
+    }
+
     let captures = Regex::new(r"^(?P<scheme>\w+):(?P<arg1>[^:]+)(:(?P<arg2>\d+))?$")
         .unwrap()
         .captures(entry)?;


### PR DESCRIPTION
Fix issue where url based entries are being processed as legacy 