### PR TITLE
webpage: stats: hub_messages_stats: Sort by system, component and message id

### DIFF
--- a/src/webpage/src/stats/hub_messages_stats.rs
+++ b/src/webpage/src/stats/hub_messages_stats.rs
@@ -54,5 +54,14 @@ impl HubMessagesStatsHistorical {
                 }
             }
         }
+
+        self.systems_messages_stats.sort_keys();
+        self.systems_messages_stats.values_mut().for_each(|system_stats| {
+            system_stats.components_messages_stats.sort_keys();
+            system_stats
+                .components_messages_stats
+                .values_mut()
+                .for_each(|component_stats| component_stats.messages_stats.sort_keys());
+        });
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0e30744f-10a9-4f1a-8756-a8575306cf2a)
