### PR TITLE
Improve drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_urlencoded",
  "shellexpand",
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ regex = "1.10.6"
 serde = { version = "1", features = ["rc"] }
 serde_derive = "1"
 serde_json = "1"
+serde_urlencoded = "0.7"
 shellexpand = "3.1"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5.4.4"

--- a/src/lib/drivers/fake.rs
+++ b/src/lib/drivers/fake.rs
@@ -517,7 +517,7 @@ mod test {
         let (hub_sender, _) = broadcast::channel(10000);
 
         let number_of_messages = 800;
-        let message_period = tokio::time::Duration::from_micros(1);
+        let message_period = tokio::time::Duration::from_millis(1);
         let timeout_time = tokio::time::Duration::from_secs(1);
 
         let source_messages = Arc::new(RwLock::new(Vec::<Arc<Protocol>>::with_capacity(1000)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::*;
 use mavlink_server::{cli, hub, logger, web};
 use tracing::*;
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     // CLI should be started before logger to allow control over verbosity
     cli::init();


### PR DESCRIPTION
Two main things here:

1. Fixes tlog aborting when lagged.

2. Now the fake source can finally be used for pressure testing!

Ex:

```bash
export PERIOD_US=10
cargo run --release -- \
  "fakesrc://?period_us=$PERIOD_US&component_id=40" \
  "fakesink://?print_as_json=false" \
  "tlogwriter://$PWD/logs/test.tlog"
```

By changing the `PERIOD_US` value, we can see how the system behaves with too much pressure, recreating the lag-snowball effect, which slows down the drivers even more.

A solution for that snowball problem could be to drop all lagged messages. While dropping messages allows the system to recover faster, that would make the system less reliant on transitory overloads. To balance that, a bigger hub channel buffer could help.

This PR doesn't touch on the pressure problem, just allows us to test it. To study it better, we also need to test transients, not only constant pressure. I'll try to think of a reliable way to test pressure using FakeSource, but that's for another PR.

