### PR TITLE
Fix udp server clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /logs
 .vscode
 /tests/files/untracked
+dev
+dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,7 +2344,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "shellexpand",
- "socket2",
  "strum",
  "strum_macros",
  "sysinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ serde_derive = "1"
 serde_json = "1"
 serde_urlencoded = "0.7"
 shellexpand = "3.1"
-socket2 = "0.5.4"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5.4.4"
 tokio-util = { version = "0.7", features = [ "codec", "net" ] }

--- a/src/lib/drivers/generic_tasks.rs
+++ b/src/lib/drivers/generic_tasks.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use mavlink_codec::{Packet, error::DecoderError};
 use tokio::sync::{RwLock, broadcast};
@@ -74,8 +74,9 @@ where
                 continue;
             }
             Some(Err(io_error)) => {
-                error!("Critical error trying to decode data from: {io_error:?}");
-                break;
+                return Err(anyhow!(
+                    "Critical error trying to decode data from: {io_error:?}"
+                ));
             }
             None => break,
         };

--- a/src/lib/drivers/udp/client.rs
+++ b/src/lib/drivers/udp/client.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use futures::{Sink, Stream, StreamExt};
 use mavlink_codec::{Packet, codec::MavlinkCodec, error::DecoderError};
 use tokio::{
@@ -197,8 +197,9 @@ where
                 continue;
             }
             Some(Err(io_error)) => {
-                error!("Critical error trying to decode data from: {io_error:?}");
-                break;
+                return Err(anyhow!(
+                    "Critical error trying to decode data from: {io_error:?}"
+                ));
             }
             None => break,
         };

--- a/src/lib/drivers/udp/server.rs
+++ b/src/lib/drivers/udp/server.rs
@@ -183,6 +183,8 @@ where
                 continue;
             }
             Some(Err(io_error)) => {
+                drop(clients); // Drop it earlier so we avoid delay in rebinds
+
                 return Err(anyhow!(
                     "Critical error trying to decode data from: {io_error:?}"
                 ));

--- a/src/lib/drivers/udp/server.rs
+++ b/src/lib/drivers/udp/server.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use futures::{Stream, StreamExt};
 use mavlink_codec::{Packet, codec::MavlinkCodec, error::DecoderError};
 use tokio::{
@@ -173,8 +173,9 @@ where
                 continue;
             }
             Some(Err(io_error)) => {
-                error!("Critical error trying to decode data from: {io_error:?}");
-                break;
+                return Err(anyhow!(
+                    "Critical error trying to decode data from: {io_error:?}"
+                ));
             }
             None => break,
         };


### PR DESCRIPTION
Reverts #168 and re-fixes #169.

The problem with the previous fix is that while it allows the UDP Server to rebind and recreate its receiving task, the sender tasks would remain alive. This was the last piece to understand the puzzle. Here's the whole bug story:

1. When a sequence of wrong CRC and truncated message arrived at the UDP Server receiving task, it was failing with the Io Error `kind: Other, error: "bytes remaining on stream"`, breaking from the loop, returning from the `udp_receive_task` with a `Result::Ok` (instead of a `Result::Error`).
2. Then, the UDP Server runner loop would try to recover by binding again to the same port, which should be fine, but because the socket was shared with the clients' task using an Arc, they would still hold the resource, preventing new bindings until MS was restarted.
3. The root cause, then, is that the clients, implemented as autonomous tasks, were outliving the UDP server receiving task, never freeing the resource.
4. By defining the UDPServer's clients (here, the `UdpCLient`), we can manually implement the `Drop` and abort its task, freeing the socket for new binds.
5. A similar issue was found in the Driver runner autonomous tasks as well, so we fixed it similarly.

---

To reproduce the problem and test this solution:
1. Run `cargo run -- udpserver:127.0.0.1:14661 --verbose`

2. Run the following Python script:

```python
#!/usr/bin/env python3

import socket
import random
import time
from pymavlink import mavutil


def create_valid_heartbeat_message():
    """Create a valid MAVLink heartbeat packet."""
    mav = mavutil.mavlink.MAVLink(None)
    msg = mavutil.mavlink.MAVLink_heartbeat_message(
        type=mavutil.mavlink.MAV_TYPE_GCS,
        autopilot=mavutil.mavlink.MAV_AUTOPILOT_INVALID,
        base_mode=0,
        custom_mode=0,
        system_status=mavutil.mavlink.MAV_STATE_ACTIVE,
        mavlink_version=3
    )
    return msg.pack(mav)


def create_invalid_crc_heartbeat_message():
    """Create a heartbeat message with broken CRC."""
    msg_bytes = create_valid_heartbeat_message()
    # Corrupt the last CRC byte
    corrupted = msg_bytes[:-1] + bytes([msg_bytes[-1] ^ 0xFF])
    return corrupted


def create_truncated_message():
    """Send the first N bytes of a heartbeat packet (simulates truncated packet)."""
    msg_bytes = create_valid_heartbeat_message()
    truncate_at = random.randint(3, len(msg_bytes) - 2)
    return msg_bytes[:truncate_at]


def create_random_noise(length=20):
    """Send pure random bytes (not valid MAVLink)."""
    return bytes(random.randint(0, 255) for _ in range(length))


def send_packet(sock, data, server_address):
    sock.sendto(data, server_address)


def main():
    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
    server_address = ('127.0.0.1', 14661)

    try:
        while True:
            mode = random.choice([
                "valid",
                "invalid_crc",
                "truncated",
                "noise",
                "combined"
            ])

            if mode == "valid":
                print("[*] Sending valid heartbeat")
                packet = create_valid_heartbeat_message()

            elif mode == "invalid_crc":
                print("[*] Sending heartbeat with invalid CRC")
                packet = create_invalid_crc_heartbeat_message()

            elif mode == "truncated":
                print("[*] Sending truncated packet")
                packet = create_truncated_message()

            elif mode == "noise":
                print("[*] Sending random noise")
                packet = create_random_noise(random.randint(10, 50))

            elif mode == "combined":
                print("[*] Sending combined packet")
                packet = (
                    create_valid_heartbeat_message() +
                    create_invalid_crc_heartbeat_message() +
                    create_truncated_message() +
                    create_random_noise(10) +
                    create_valid_heartbeat_message()
                )

            send_packet(sock, packet, server_address)

            # Wait a bit between sends, adjust as needed
            time.sleep(0.5)

    except KeyboardInterrupt:
        print("\nExiting...")

    finally:
        sock.close()


if __name__ == "__main__":
    main()
```

3. Check if MavlinkServer can recover from the error.

---

Thanks