### PR TITLE
docs: add usage instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Download the binaries available on the [latest release](https://github.com/bluer
 mavlink-server [OPTIONS] [ENDPOINTS]...
 ```
 
-`[ENDPOINTS]` is a space-separated list of connection endpoints.
+`[ENDPOINTS]` is a space-separated list of connection endpoints, that follows the same convention as other tools, such as mavlink-router, mavp2p, and etc.
 Examples include serial ports, UDP/TCP sockets, or log readers.
 
 ## Endpoint Examples


### PR DESCRIPTION
Added a detailed usage section to the README file to help users understand how to configure and run the tool, including available command-line options and endpoint examples. This should improve onboarding and ease of use for new users.