### PR TITLE
.github: Install cargo fmt before using it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable --profile minimal --target x86_64-unknown-linux-musl,wasm32-unknown-unknown -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Install rustfmt
+        run: rustup component add rustfmt
       - name: Check code style
         run: cargo fmt -- --check
 


### PR DESCRIPTION
Fixes:
<img width="684" height="117" alt="image" src="https://github.com/user-attachments/assets/924054f1-d2b7-452c-bf0a-0ec8a5c1c781" />
