### PR TITLE
fix: --version now reports git tag instead of hardcoded 0.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+          fetch-tags: true
 
       - name: Install build dependencies - Rustup
         run: |
@@ -71,6 +72,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+          fetch-tags: true
 
       # Required for cargo-binstall
       - name: Fix openssl on Windows

--- a/build.rs
+++ b/build.rs
@@ -77,9 +77,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Path::new(&out_dir).join("src/lib/drivers/rest/autopilot/parameters/ardupilot_parameters");
     println!("cargo:rerun-if-changed={}", params_src.display());
 
+    let gix = GixBuilder::default()
+        .all()
+        .describe(true, false, None)
+        .build()?;
+
     vergen_gix::Emitter::default()
         .add_instructions(&BuildBuilder::all_build()?)?
-        .add_instructions(&GixBuilder::all_git()?)?
+        .add_instructions(&gix)?
         .add_instructions(
             CargoBuilder::all_cargo()?.set_dep_kind_filter(Some(DependencyKind::Normal)),
         )?

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -14,7 +14,7 @@ struct Manager {
 
 #[derive(Debug, Parser)]
 #[command(
-    version = env!("CARGO_PKG_VERSION"),
+    version = env!("VERGEN_GIT_DESCRIBE"),
     author = env!("CARGO_PKG_AUTHORS"),
     about = env!("CARGO_PKG_DESCRIPTION")
 )]


### PR DESCRIPTION
Closes #208

### Root cause
`--version` was reading `CARGO_PKG_VERSION`, which is hardcoded to `0.1.0` in `Cargo.toml` and never updated on releases.

### Fix
Switch to `VERGEN_GIT_DESCRIBE`, which is already generated by `vergen-gix` during the build and reflects the actual git tag.

Two additional issues had to be addressed to make this work:

  1. `GixBuilder::all_git()` calls `.describe(false, false, None)` internally, where the first argument means "annotated tags only". This repo uses lightweight tags, so git describe found nothing and emitted an empty string. Fixed by calling `.all().describe(true, false, None)` to include all tags.
  2. `actions/checkout@v4` defaults to a shallow clone with no tags. Added `fetch-tags: true` to both checkout steps so tags are visible during CI builds.

### Result
**On a tagged commit:** `mavlink-server 0.8.0`
**Between releases:** `mavlink-server 0.8.0-16-gbfc96df`