### PR TITLE
lib: drivers: serial: Fix Windows COM parse

### DIFF
--- a/src/lib/drivers/serial/mod.rs
+++ b/src/lib/drivers/serial/mod.rs
@@ -184,20 +184,39 @@ impl DriverInfo for SerialInfo {
     }
 
     fn create_endpoint_from_url(&self, url: &url::Url) -> Option<Arc<dyn Driver>> {
-        let port_name = url.path().to_string();
-        let baud_rate = url
-            .query_pairs()
-            .find_map(|(key, value)| {
-                if key == "baudrate" || key == "arg2" {
-                    value.parse().ok()
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(115200); // Commun baudrate between flight controllers
-
+        let (port_name, baud_rate) = port_and_baud_from_url(url);
         Some(Arc::new(
             Serial::builder("Serial", &port_name, baud_rate).build(),
         ))
     }
+}
+
+fn port_and_baud_from_url(url: &url::Url) -> (String, u32) {
+    let mut port_name = url.path().to_string();
+    // Keep the slash on unix paths like /dev/ttyACM0. Strip it on COM
+    // ports: serialport prepends \\.\ unless the path already starts
+    // with \, so /COM3 fails to open.
+    if port_name.is_empty() || port_name == "/" {
+        port_name = url.host_str().unwrap_or("").to_string();
+    } else if port_name
+        .trim_start_matches('/')
+        .to_ascii_uppercase()
+        .starts_with("COM")
+    {
+        port_name = port_name.trim_start_matches('/').to_string();
+    }
+
+    let baud_rate = url
+        .query_pairs()
+        .find_map(|(key, value)| {
+            if key == "baudrate" || key == "arg2" {
+                value.parse().ok()
+            } else {
+                None
+            }
+        })
+        .or_else(|| url.port().map(u32::from))
+        .unwrap_or(115200); // Commun baudrate between flight controllers
+
+    (port_name, baud_rate)
 }

--- a/src/lib/drivers/serial/mod.rs
+++ b/src/lib/drivers/serial/mod.rs
@@ -220,3 +220,43 @@ fn port_and_baud_from_url(url: &url::Url) -> (String, u32) {
 
     (port_name, baud_rate)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drivers::{DriverDescriptionLegacy, DriverInfo, Type};
+
+    #[test]
+    fn port_and_baud_from_url_parses_windows_and_unix() {
+        let cases = [
+            ("serial://COM3:57600", "COM3", 57600),
+            ("serial://COM1?baudrate=57600", "COM1", 57600),
+            ("serial://COM1?arg2=115200", "COM1", 115200),
+            ("serial:///COM3?baudrate=57600", "COM3", 57600),
+            (
+                "serial:///dev/ttyACM0?baudrate=115200",
+                "/dev/ttyACM0",
+                115200,
+            ),
+        ];
+
+        for (input, expected_port, expected_baud) in cases {
+            let url = url::Url::parse(input).unwrap();
+            let (port, baud) = port_and_baud_from_url(&url);
+            assert_eq!(port, expected_port, "{input}");
+            assert_eq!(baud, expected_baud, "{input}");
+        }
+    }
+
+    #[test]
+    fn port_and_baud_from_legacy_com() {
+        let url = SerialInfo
+            .url_from_legacy(DriverDescriptionLegacy {
+                typ: Type::Serial,
+                arg1: "COM3".to_string(),
+                arg2: Some("57600".to_string()),
+            })
+            .unwrap();
+        assert_eq!(port_and_baud_from_url(&url), ("COM3".to_string(), 57600));
+    }
+}


### PR DESCRIPTION
Legacy serial:COM3:57600 stores the port as the URL host and the baud as the URL port, so path is empty.

Fix #211