### PR TITLE
stats: driver: Add endpoint field

### DIFF
--- a/src/lib/drivers/fake.rs
+++ b/src/lib/drivers/fake.rs
@@ -47,6 +47,7 @@ impl FakeSink {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &FakeSinkInfo,
+                "",
             ))),
         })
     }
@@ -270,6 +271,7 @@ impl FakeSource {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &FakeSourceInfo,
+                "",
             ))),
             system_id: params.system_id,
             component_id: params.component_id,

--- a/src/lib/drivers/mod.rs
+++ b/src/lib/drivers/mod.rs
@@ -330,6 +330,7 @@ mod tests {
                 stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                     name,
                     &ExampleDriverInfo,
+                    "",
                 ))),
             })
         }

--- a/src/lib/drivers/rest/mod.rs
+++ b/src/lib/drivers/rest/mod.rs
@@ -65,7 +65,9 @@ impl Rest {
             uuid: Self::generate_uuid(&name),
             on_message_input: Callbacks::default(),
             on_message_output: Callbacks::default(),
-            stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(name, &RestInfo))),
+            stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
+                name, &RestInfo, "",
+            ))),
         })
     }
 

--- a/src/lib/drivers/serial/mod.rs
+++ b/src/lib/drivers/serial/mod.rs
@@ -68,7 +68,11 @@ impl Serial {
             baud_rate,
             on_message_input: Callbacks::default(),
             on_message_output: Callbacks::default(),
-            stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(name, &SerialInfo))),
+            stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
+                name,
+                &SerialInfo,
+                &format!("{port_name}:{baud_rate}"),
+            ))),
         })
     }
 }

--- a/src/lib/drivers/tcp/client.rs
+++ b/src/lib/drivers/tcp/client.rs
@@ -78,6 +78,7 @@ impl TcpClient {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &TcpClientInfo,
+                remote_addr,
             ))),
         })
     }

--- a/src/lib/drivers/tcp/server.rs
+++ b/src/lib/drivers/tcp/server.rs
@@ -78,6 +78,7 @@ impl TcpServer {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &TcpServerInfo,
+                local_addr,
             ))),
         })
     }

--- a/src/lib/drivers/tlog/reader.rs
+++ b/src/lib/drivers/tlog/reader.rs
@@ -62,6 +62,7 @@ impl TlogReader {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &TlogReaderInfo,
+                &path_str,
             ))),
         })
     }

--- a/src/lib/drivers/tlog/writer.rs
+++ b/src/lib/drivers/tlog/writer.rs
@@ -81,6 +81,7 @@ impl TlogWriter {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &TlogWriterInfo,
+                &path_str,
             ))),
         })
     }

--- a/src/lib/drivers/udp/client.rs
+++ b/src/lib/drivers/udp/client.rs
@@ -77,6 +77,7 @@ impl UdpClient {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &UdpClientInfo,
+                remote_addr,
             ))),
         })
     }

--- a/src/lib/drivers/udp/server.rs
+++ b/src/lib/drivers/udp/server.rs
@@ -97,6 +97,7 @@ impl UdpServer {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &UdpServerInfo,
+                local_addr,
             ))),
         })
     }

--- a/src/lib/drivers/websocket/client.rs
+++ b/src/lib/drivers/websocket/client.rs
@@ -86,6 +86,7 @@ impl WebSocketClientDriver {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &WebSocketClientInfo,
+                remote_addr,
             ))),
         })
     }

--- a/src/lib/drivers/websocket/server.rs
+++ b/src/lib/drivers/websocket/server.rs
@@ -94,6 +94,7 @@ impl WebSocketServerDriver {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &WebSocketServerInfo,
+                local_addr,
             ))),
         })
     }

--- a/src/lib/drivers/zenoh/json.rs
+++ b/src/lib/drivers/zenoh/json.rs
@@ -63,7 +63,9 @@ impl Zenoh {
             uuid: Self::generate_uuid(&name),
             on_message_input: Callbacks::default(),
             on_message_output: Callbacks::default(),
-            stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(name, &ZenohInfo))),
+            stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
+                name, &ZenohInfo, "",
+            ))),
         })
     }
 

--- a/src/lib/drivers/zenoh/raw.rs
+++ b/src/lib/drivers/zenoh/raw.rs
@@ -68,6 +68,7 @@ impl ZenohRaw {
             stats: Arc::new(RwLock::new(AccumulatedDriverStats::new(
                 name,
                 &ZenohRawInfo,
+                "",
             ))),
         })
     }

--- a/src/lib/stats/accumulated/driver.rs
+++ b/src/lib/stats/accumulated/driver.rs
@@ -18,14 +18,16 @@ pub trait AccumulatedDriverStatsProvider {
 pub struct AccumulatedDriverStats {
     pub name: Arc<String>,
     pub driver_type: &'static str,
+    pub endpoint: String,
     pub stats: AccumulatedDriverStatsInner,
 }
 
 impl AccumulatedDriverStats {
-    pub fn new(name: Arc<String>, info: &dyn DriverInfo) -> Self {
+    pub fn new(name: Arc<String>, info: &dyn DriverInfo, endpoint: &str) -> Self {
         Self {
             name,
             driver_type: info.name(),
+            endpoint: endpoint.to_string(),
             stats: AccumulatedDriverStatsInner::default(),
         }
     }

--- a/src/lib/stats/actor.rs
+++ b/src/lib/stats/actor.rs
@@ -488,6 +488,7 @@ async fn update_driver_stats(
                 DriverStats {
                     name: current_stats.name.clone(),
                     driver_type: current_stats.driver_type,
+                    endpoint: current_stats.endpoint.clone(),
                     stats: DriverStatsInner {
                         input: new_input_stats,
                         output: new_output_stats,

--- a/src/lib/stats/driver.rs
+++ b/src/lib/stats/driver.rs
@@ -13,6 +13,7 @@ pub type DriversStats = IndexMap<DriverUuid, DriverStats>;
 pub struct DriverStats {
     pub name: Arc<String>,
     pub driver_type: &'static str,
+    pub endpoint: String,
     pub stats: DriverStatsInner,
 }
 

--- a/src/webpage/src/stats/drivers_stats.rs
+++ b/src/webpage/src/stats/drivers_stats.rs
@@ -22,6 +22,7 @@ pub struct DriversStats<B, M, D> {
 pub struct DriverStats<B, M, D> {
     pub name: String,
     pub driver_type: String,
+    pub endpoint: String,
     pub stats: DriverStatsInner<B, M, D>,
 }
 
@@ -42,6 +43,7 @@ impl DriversStatsHistorical {
                 .or_insert(DriverStats {
                     name: sample_driver_stats.name,
                     driver_type: sample_driver_stats.driver_type,
+                    endpoint: sample_driver_stats.endpoint,
                     stats: Default::default(),
                 });
 

--- a/src/webpage/src/widgets/driver_stats.rs
+++ b/src/webpage/src/widgets/driver_stats.rs
@@ -79,6 +79,15 @@ impl<'a> DriverStatsWidget<'a> {
 
                         body.row(15., |mut row| {
                             row.col(|ui| {
+                                ui.label("Endpoint");
+                            });
+                            row.col(|ui| {
+                                ui.label(&driver_stats.endpoint);
+                            });
+                        });
+
+                        body.row(15., |mut row| {
+                            row.col(|ui| {
                                 ui.label("UUID");
                             });
                             row.col(|ui| {


### PR DESCRIPTION
The stats page only shows name, type and UUID.

<img width="470" height="141" alt="image" src="https://github.com/user-attachments/assets/27b11193-6356-4e87-9395-2ac768ccfbfc" />


Fix #167